### PR TITLE
Add riscv64 wheel build workflow

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -1,0 +1,58 @@
+name: Build riscv64 wheel
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Upstream release tag to build from (e.g. v0.5.3)'
+        required: false
+        type: string
+  schedule:
+    - cron: '0 2 * * 0'
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, riscv64]
+    timeout-minutes: 120
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        run: |
+          python3 -m venv /tmp/build-venv
+          . /tmp/build-venv/bin/activate
+          pip install --upgrade pip maturin
+
+      - name: Build wheel
+        run: |
+          . /tmp/build-venv/bin/activate
+          maturin build --release --out /tmp/wheels/ --manifest-path bindings/python/Cargo.toml
+
+      - name: Verify platform tag
+        run: |
+          ls /tmp/wheels/*.whl
+          for whl in /tmp/wheels/*.whl; do
+            if echo "$whl" | grep -q "linux_riscv64\|manylinux.*riscv64"; then
+              echo "OK: $whl"
+            else
+              echo "FAIL: $whl does not have riscv64 platform tag"
+              exit 1
+            fi
+          done
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-riscv64
+          path: /tmp/wheels/*.whl
+          retention-days: 90
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf /tmp/build-venv /tmp/wheels


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for building riscv64 Python wheels
- Uses self-hosted runner on BananaPi F3 (SpacemiT K1, rv64imafdcv)
- Triggers: weekly schedule + manual dispatch with optional tag input
- Builds with maturin and uploads wheel as artifact