### PR TITLE
fix: add checkout to release job and use DISPATCH_TOKEN

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -62,6 +62,9 @@ jobs:
     runs-on: [self-hosted, linux, riscv64]
     if: success()
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download wheel artifact
         uses: actions/download-artifact@v4
         with:
@@ -122,10 +125,9 @@ jobs:
     steps:
       - name: Trigger index update
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           gh api repos/gounthar/riscv64-python-wheels/dispatches \
             -f event_type=fork-release-published \
             -f "client_payload[repo]=${{ github.repository }}" \
-            -f "client_payload[tag]=${{ github.ref_name }}" || true
-
+            -f "client_payload[tag]=${{ github.ref_name }}"


### PR DESCRIPTION
## Summary

Two fixes to the riscv64 build workflow:

1. **Add `actions/checkout@v4` to the `release` job** — `gh release create`
   needs a git repository context to work. Without checkout, the job fails
   with `fatal: not a git repository`.

2. **Use `DISPATCH_TOKEN` instead of `GITHUB_TOKEN`** in the `notify-index`
   job — `GITHUB_TOKEN` is scoped to this repo only and cannot trigger
   `repository_dispatch` on the central wheels repo. Also removes `|| true`
   so errors surface in CI logs.

## Setup required

Add `DISPATCH_TOKEN` secret to this repo (PAT with `repo` + `workflow` scopes).