### PR TITLE
ci: build riscv64 wheel on RISE runner via uv

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, riscv64]
+    runs-on: ubuntu-24.04-riscv
     timeout-minutes: 120
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
@@ -23,15 +23,18 @@ jobs:
           ref: ${{ inputs.release_tag || github.ref }}
           fetch-depth: 0
 
-      - name: Set up Python
-        run: |
-          python3 -m venv /tmp/build-venv
-          . /tmp/build-venv/bin/activate
-          pip install --upgrade pip maturin
+      # Build on the RISE ubuntu-24.04-riscv runner with uv, matching the
+      # working httptools build. The self-hosted F3 board caused weekly
+      # runner-contention failures, and its bare python3 is absent on RISE
+      # runners - uv provisions a managed riscv64 Python instead.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Build wheel
         run: |
+          uv venv --python 3.12 /tmp/build-venv
           . /tmp/build-venv/bin/activate
+          uv pip install --upgrade maturin
           maturin build --release --out /tmp/wheels/ --manifest-path bindings/python/Cargo.toml
 
       - name: Verify platform tag
@@ -59,7 +62,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: [self-hosted, linux, riscv64]
+    runs-on: ubuntu-latest
     if: success()
     env:
       GH_REPO: ${{ github.repository }}
@@ -104,10 +107,9 @@ jobs:
           # Create new release
           gh release create "$TAG" \
             --title "$TITLE" \
-            --notes "Prebuilt riscv64 wheel for $(uname -m) Linux.
+            --notes "Prebuilt riscv64 wheel for Linux.
 
-          Built on: BananaPi F3 (SpacemiT K1, rv64imafdcv)
-          Python: $(python3 --version 2>&1)
+          Built on: RISE riscv64 runner (ubuntu-24.04-riscv)
           Wheel: ${{ steps.wheel_info.outputs.whl_name }}
 
           Install:


### PR DESCRIPTION
Reviving this workflow (currently `disabled_manually`, no runs since 2026-03-29).

This fork is **not** redundant: upstream `safetensors` ships riscv64 wheels only in 0.8.0 pre-releases; the latest stable (0.7.0) has none, so this build is the only stable riscv64 wheel source.

If re-enabled as-is it would fail: the `build`/`release` jobs target the shared self-hosted F3 board (weekly contention with other fork builds), and that board's bare `python3` is absent on RISE runners.

## Change

- `build` → `runs-on: ubuntu-24.04-riscv` (RISE native runner) + `astral-sh/setup-uv` + `uv venv --python 3.12`, matching the sibling **httptools** build that runs there green. maturin/venv flow otherwise unchanged (`--manifest-path bindings/python/Cargo.toml` preserved).
- `release` → `runs-on: ubuntu-latest` (only downloads the artifact + creates a release; no riscv64 needed), and corrected the now-inaccurate "Built on: BananaPi F3" note to "RISE riscv64 runner".

After merge, the schedule still needs re-enabling (`gh workflow enable build-riscv64.yml`) — enabling before merge would just rerun the broken version.